### PR TITLE
Fix Solana swap default token load

### DIFF
--- a/apps/web/src/hooks/useSolanaTokenList.ts
+++ b/apps/web/src/hooks/useSolanaTokenList.ts
@@ -10,14 +10,14 @@ import { useQuery } from '@tanstack/react-query'
 import { SOLANA_LISTS_CONFIG, TokenListKey, USER_ADDED_KEY, convertRawTokenInfoIntoSPLToken } from 'config/solana-list'
 
 // Custom hook for individual token list queries
-function useTokenListQuery(listKey: TokenListKey) {
+function useTokenListQuery(listKey: TokenListKey, enabled: boolean) {
   const listSettings = useAtomValue(solanaListSettingsAtom)
   // PancakeSwap list is always enabled
   const isEnabled = listKey === TokenListKey.PANCAKESWAP ? true : listSettings[listKey]
   const listConfig = SOLANA_LISTS_CONFIG[listKey]
 
   return useQuery({
-    queryKey: ['solana-token-list', listConfig.key, isEnabled],
+    queryKey: ['solana-token-list', listConfig.key, isEnabled && enabled],
     queryFn: async () => {
       const res = await fetch(listConfig.apiUrl)
       if (!res.ok) {
@@ -29,7 +29,7 @@ function useTokenListQuery(listKey: TokenListKey) {
     retry: 3,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    enabled: isEnabled,
+    enabled: isEnabled && enabled,
     select: (data) => {
       return listConfig.parser(data)
     },
@@ -48,14 +48,14 @@ function saveUserAddedTokens(tokens: TokenInfo[]) {
   localStorage.setItem(USER_ADDED_KEY, JSON.stringify(tokens))
 }
 
-export function useSolanaTokenList() {
+export function useSolanaTokenList(enabled = true) {
   const [userTokens, setUserTokens] = useState<TokenInfo[]>(getUserAddedTokens())
   const setTokenList = useSetAtom(solanaTokenListAtom)
 
   // Create individual queries for each token list using the custom hook
-  const { data: pcsTokens, isLoading: pcsLoading } = useTokenListQuery(TokenListKey.PANCAKESWAP)
-  const { data: raydiumTokens, isLoading: raydiumLoading } = useTokenListQuery(TokenListKey.RAYDIUM)
-  const { data: jupiterTokens, isLoading: jupiterLoading } = useTokenListQuery(TokenListKey.JUPITER)
+  const { data: pcsTokens, isLoading: pcsLoading } = useTokenListQuery(TokenListKey.PANCAKESWAP, enabled)
+  const { data: raydiumTokens, isLoading: raydiumLoading } = useTokenListQuery(TokenListKey.RAYDIUM, enabled)
+  const { data: jupiterTokens, isLoading: jupiterLoading } = useTokenListQuery(TokenListKey.JUPITER, enabled)
 
   const mergedTokens = useMemo(() => {
     const seen = new Set<string>()

--- a/apps/web/src/views/SwapSimplify/index.tsx
+++ b/apps/web/src/views/SwapSimplify/index.tsx
@@ -5,6 +5,9 @@ import { useAtom } from 'jotai'
 
 import { MobileCard } from 'components/AdPanel/MobileCard'
 import { useCurrency } from 'hooks/Tokens'
+import { useSolanaTokenList } from 'hooks/useSolanaTokenList'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { NonEVMChainId } from '@pancakeswap/chains'
 import { AutoSlippageProvider } from 'hooks/useAutoSlippageWithFallback'
 import { useSwapHotTokenDisplay } from 'hooks/useSwapHotTokenDisplay'
 import dynamic from 'next/dynamic'
@@ -29,6 +32,7 @@ const Wrapper = styled(Box)`
 
 const InfinitySwapInner = () => {
   const { query } = useRouter()
+  const { chainId } = useActiveChainId()
   const { isMobile, isDesktop } = useMatchBreakpoints()
   const { isChartExpanded } = useContext(SwapFeaturesContext)
   const [isChartDisplayed, setIsChartDisplayed] = useAtom(chartDisplayAtom)
@@ -43,6 +47,10 @@ const InfinitySwapInner = () => {
 
   const inputCurrency = useCurrency(inputCurrencyId, inputChainId)
   const outputCurrency = useCurrency(outputCurrencyId, outputChainId)
+
+  // Prefetch Solana tokens when user switches to Solana
+  useSolanaTokenList(chainId === NonEVMChainId.SOLANA)
+
 
   useEffect(() => {
     if (firstTime && query.showTradingReward) {


### PR DESCRIPTION
## Summary
- load Solana token list whenever the active chain is Solana
- allow enabling/disabling of the Solana token list hook

## Testing
- `pnpm lint`
- `pnpm test:ci` *(fails: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_688b617000ec832097fea6759bab0929