### PR TITLE
feat(solana): fetch unknown token metadata in search

### DIFF
--- a/apps/web/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearch.tsx
@@ -4,6 +4,7 @@ import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useUnifiedNativeCurrency } from 'hooks/useNativeCurrency'
 import { useSolanaTokenList } from 'hooks/useSolanaTokenList'
+import { useSolanaTokenInfo } from 'hooks/solana/useSolanaTokenInfo'
 import { FixedSizeList } from 'react-window'
 import { useAllLists, useInactiveListUrls } from 'state/lists/hooks'
 import { UpdaterByChainId } from 'state/lists/updater'
@@ -34,6 +35,7 @@ import {
 } from '@pancakeswap/uikit'
 import { useAudioPlay } from '@pancakeswap/utils/user'
 import { useSolanaTokenBalances } from 'state/token/solanaTokenBalances'
+import { SPLToken } from '@pancakeswap/swap-sdk-core'
 
 import { useAllTokens, useIsUserAddedToken, useToken } from '../../hooks/Tokens'
 import Row from '../Layout/Row'
@@ -41,6 +43,7 @@ import CommonBases, { BaseWrapper } from './CommonBases'
 import CurrencyList from './CurrencyList'
 import { CurrencySearchInput } from './CurrencySearchInput'
 import ImportRow from './ImportRow'
+import SolanaImportRow from './SolanaImportRow'
 import SwapNetworkSelection from './SwapNetworkSelection'
 import { getSwapSound } from './swapSound'
 import { CommonBasesType } from './types'
@@ -157,10 +160,15 @@ function CurrencySearch({
   // Solana balances integration
   const solanaBalances = useSolanaTokenBalances(solanaAccount, tokenAddresses)
 
-  const searchToken = useToken(debouncedQuery, selectedChainId)
+  const solanaSearchToken = useSolanaTokenInfo(isSolana ? debouncedQuery : undefined)
+  const evmSearchToken = useToken(debouncedQuery, selectedChainId)
+  const searchToken = isSolana ? solanaSearchToken : evmSearchToken
 
   // if they input an address, use it
-  const searchTokenIsAdded = useIsUserAddedToken(searchToken, selectedChainId)
+  const evmSearchTokenIsAdded = useIsUserAddedToken(evmSearchToken, selectedChainId)
+  const searchTokenIsAdded = isSolana
+    ? !!solanaTokens.find((t) => t.address === (searchToken as SPLToken | undefined)?.address)
+    : evmSearchTokenIsAdded
 
   // if no results on main list, show option to expand into inactive
   const filteredInactiveTokens = useSearchInactiveTokenLists(debouncedQuery)
@@ -255,13 +263,22 @@ function CurrencySearch({
     if (searchToken && !searchTokenIsAdded && !hasFilteredInactiveTokens) {
       return (
         <Column style={{ padding: '20px 0', height: '100%' }}>
-          <ImportRow
-            chainId={selectedChainId}
-            onCurrencySelect={handleCurrencySelect}
-            token={searchToken}
-            showImportView={showImportView}
-            setImportToken={setImportToken}
-          />
+          {isSolana ? (
+            <SolanaImportRow
+              token={searchToken as SPLToken}
+              onCurrencySelect={handleCurrencySelect as (c: SPLToken) => void}
+              showImportView={showImportView}
+              setImportToken={setImportToken as unknown as (t: SPLToken) => void}
+            />
+          ) : (
+            <ImportRow
+              chainId={selectedChainId}
+              onCurrencySelect={handleCurrencySelect}
+              token={searchToken}
+              showImportView={showImportView}
+              setImportToken={setImportToken}
+            />
+          )}
         </Column>
       )
     }

--- a/apps/web/src/components/SearchModal/SolanaImportRow.tsx
+++ b/apps/web/src/components/SearchModal/SolanaImportRow.tsx
@@ -1,0 +1,52 @@
+import { Flex, Button, Text } from '@pancakeswap/uikit'
+import { CurrencyLogo } from '@pancakeswap/widgets-internal'
+import { SPLToken } from '@pancakeswap/swap-sdk-core'
+import { CSSProperties } from 'react'
+
+interface SolanaImportRowProps {
+  token: SPLToken
+  style?: CSSProperties
+  onCurrencySelect?: (currency: SPLToken) => void
+  showImportView: () => void
+  setImportToken: (token: SPLToken) => void
+}
+
+export default function SolanaImportRow({
+  token,
+  style,
+  onCurrencySelect,
+  showImportView,
+  setImportToken,
+}: SolanaImportRowProps) {
+  return (
+    <Flex style={style} alignItems="center" justifyContent="space-between" padding="4px 20px">
+      <Flex
+        flex="1"
+        alignItems="center"
+        minWidth={0}
+        onClick={() => onCurrencySelect?.(token)}
+        style={{ cursor: 'pointer' }}
+      >
+        <CurrencyLogo currency={token} size="24px" />
+        <Flex flexDirection="column" ml="12px" overflow="hidden">
+          <Text bold ellipsis>
+            {token.symbol}
+          </Text>
+          <Text fontSize="12px" color="textSubtle" ellipsis>
+            {token.name}
+          </Text>
+        </Flex>
+      </Flex>
+      <Button
+        scale="sm"
+        onClick={(e) => {
+          e.stopPropagation()
+          setImportToken(token)
+          showImportView()
+        }}
+      >
+        Import
+      </Button>
+    </Flex>
+  )
+}

--- a/apps/web/src/hooks/solana/useSolanaTokenInfo.ts
+++ b/apps/web/src/hooks/solana/useSolanaTokenInfo.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { PublicKey } from '@solana/web3.js'
+import type { TokenInfo } from '@pancakeswap/solana-core-sdk'
+import { SPLToken } from '@pancakeswap/swap-sdk-core'
+import { convertRawTokenInfoIntoSPLToken } from 'config/solana-list'
+import { useSolanaTokenList } from 'hooks/useSolanaTokenList'
+
+const API_ENDPOINT = process.env.NEXT_PUBLIC_SOLANA_EXPLORE_API_ENDPOINT
+
+const isValidAddress = (address?: string) => {
+  if (!address) return false
+  try {
+    // will throw if invalid
+    const _ = new PublicKey(address)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function useSolanaTokenInfo(address?: string): SPLToken | undefined | null {
+  const { tokenList } = useSolanaTokenList()
+  const token = useMemo(() => tokenList.find((t) => t.address === address), [tokenList, address])
+
+  const enabled = !token && isValidAddress(address)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['solana-token-info', address],
+    queryFn: async () => {
+      if (!address || !API_ENDPOINT) return undefined
+      const resp = await fetch(`${API_ENDPOINT}/cached/v1/tokens/metadata/${address}`)
+      if (!resp.ok) throw new Error('Failed to fetch token metadata')
+      const json = await resp.json()
+      const info = json?.data as TokenInfo | undefined
+      return info ? convertRawTokenInfoIntoSPLToken(info) : undefined
+    },
+    enabled,
+    staleTime: Infinity,
+  })
+
+  if (token) return token
+  if (enabled && isLoading) return null
+  return data
+}


### PR DESCRIPTION
## Summary
- add hook to fetch solana token metadata from API when address missing from list
- support importing fetched tokens with a dedicated row in search modal
- wire solana search modal to new hook and row

## Testing
- `pnpm lint --filter web`
- `pnpm --filter web test` *(fails: Failed to resolve entry for package "@pancakeswap/chains" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68906a37020083208c6a35fc56538893