### PR TITLE
fix sol input balance check

### DIFF
--- a/apps/web/src/utils/maxAmountSpend.test.ts
+++ b/apps/web/src/utils/maxAmountSpend.test.ts
@@ -1,5 +1,5 @@
-import { CurrencyAmount, Native } from '@pancakeswap/sdk'
-import { maxAmountSpend } from './maxAmountSpend'
+import { CurrencyAmount, Native, SOL } from '@pancakeswap/sdk'
+import { maxAmountSpend, maxUnifiedAmountSpend } from './maxAmountSpend'
 
 describe('maxAmountSpend', () => {
   it('should be undefined if no input', () => {
@@ -14,5 +14,17 @@ describe('maxAmountSpend', () => {
 
   it('should be 0 when CurrencyAmount is BNB and CurrencyAmount is low', () => {
     expect(maxAmountSpend(CurrencyAmount.fromRawAmount(Native.onChain(56), '0')).quotient === 0n).toBeTruthy()
+  })
+})
+
+describe('maxUnifiedAmountSpend', () => {
+  it('should has value when CurrencyAmount is SOL and CurrencyAmount is higher than min reserve', () => {
+    const maxAmount = maxUnifiedAmountSpend(CurrencyAmount.fromRawAmount(SOL, 10n ** 8n))
+
+    expect(maxAmount.quotient > 0n).toBeTruthy()
+  })
+
+  it('should be 0 when CurrencyAmount is SOL and CurrencyAmount is low', () => {
+    expect(maxUnifiedAmountSpend(CurrencyAmount.fromRawAmount(SOL, 0n)).quotient === 0n).toBeTruthy()
   })
 })

--- a/apps/web/src/views/Swap/Bridge/CrossChainConfirmSwapModal/TransactionConfirmSwapContentV3.tsx
+++ b/apps/web/src/views/Swap/Bridge/CrossChainConfirmSwapModal/TransactionConfirmSwapContentV3.tsx
@@ -2,7 +2,7 @@ import { Currency, CurrencyAmount, TradeType } from '@pancakeswap/sdk'
 import { ConfirmationModalContent } from '@pancakeswap/widgets-internal'
 import { memo, useCallback, useMemo } from 'react'
 import { Field } from 'state/swap/actions'
-import { maxAmountSpend } from 'utils/maxAmountSpend'
+import { maxUnifiedAmountSpend } from 'utils/maxAmountSpend'
 import { computeBridgeOrderFee } from 'views/Swap/Bridge/utils'
 import { EVMInterfaceOrder, InterfaceOrder, isBridgeOrder, isXOrder } from 'views/Swap/utils'
 import {
@@ -73,12 +73,7 @@ export const TransactionConfirmSwapContentV3 = memo<TransactionConfirmSwapConten
       if (order?.trade?.tradeType !== TradeType.EXACT_OUTPUT) return null
 
       const isInputBalanceExist = !!(currencyBalances && currencyBalances[Field.INPUT])
-      const isInputBalanceBNB = isInputBalanceExist && currencyBalances[Field.INPUT]?.currency.isNative
-      const inputCurrencyAmount = isInputBalanceExist
-        ? isInputBalanceBNB
-          ? maxAmountSpend(currencyBalances[Field.INPUT])
-          : currencyBalances[Field.INPUT]
-        : null
+      const inputCurrencyAmount = isInputBalanceExist ? maxUnifiedAmountSpend(currencyBalances[Field.INPUT]) : null
       return inputCurrencyAmount && slippageAdjustedAmounts && slippageAdjustedAmounts[Field.INPUT]
         ? inputCurrencyAmount.greaterThan(slippageAdjustedAmounts[Field.INPUT]) ||
             inputCurrencyAmount.equalTo(slippageAdjustedAmounts[Field.INPUT])

--- a/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContentV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContentV2.tsx
@@ -3,7 +3,7 @@ import { Currency, CurrencyAmount, TradeType } from '@pancakeswap/sdk'
 import { ConfirmationModalContent } from '@pancakeswap/widgets-internal'
 import { memo, useCallback, useMemo } from 'react'
 import { Field } from 'state/swap/actions'
-import { maxAmountSpend } from 'utils/maxAmountSpend'
+import { maxUnifiedAmountSpend } from 'utils/maxAmountSpend'
 import SwapModalHeaderV2 from 'views/Swap/components/SwapModalHeaderV2'
 import { EVMInterfaceOrder, getPriceBreakdown, InterfaceOrder } from 'views/Swap/utils'
 import {
@@ -70,12 +70,7 @@ export const TransactionConfirmSwapContentV2 = memo<TransactionConfirmSwapConten
       if (order?.trade?.tradeType !== TradeType.EXACT_OUTPUT) return null
 
       const isInputBalanceExist = !!(currencyBalances && currencyBalances[Field.INPUT])
-      const isInputBalanceBNB = isInputBalanceExist && currencyBalances[Field.INPUT]?.currency.isNative
-      const inputCurrencyAmount = isInputBalanceExist
-        ? isInputBalanceBNB
-          ? maxAmountSpend(currencyBalances[Field.INPUT])
-          : currencyBalances[Field.INPUT]
-        : null
+      const inputCurrencyAmount = isInputBalanceExist ? maxUnifiedAmountSpend(currencyBalances[Field.INPUT]) : null
       return inputCurrencyAmount && slippageAdjustedAmounts && slippageAdjustedAmounts[Field.INPUT]
         ? inputCurrencyAmount.greaterThan(slippageAdjustedAmounts[Field.INPUT]) ||
             inputCurrencyAmount.equalTo(slippageAdjustedAmounts[Field.INPUT])


### PR DESCRIPTION
## Summary
- use `maxUnifiedAmountSpend` for native token checks in swap confirmation components
- add unit tests for `maxUnifiedAmountSpend`

## Testing
- `pnpm --filter @pancakeswap/chains build`
- `pnpm --filter @pancakeswap/tokens build` *(fails: Cannot find module '@pancakeswap/chains')*
- `pnpm --filter web test src/utils/maxAmountSpend.test.ts` *(fails: Failed to resolve entry for package "@pancakeswap/swap-sdk-core")*


------
https://chatgpt.com/codex/tasks/task_e_68906d7023b08320a3fb86e6c77a559d