### PR TITLE
feat: move solana unwrap tip to swap button

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -14,33 +14,23 @@ import {
   WarningIcon,
   useMatchBreakpoints,
   useTooltip,
-  CircleInfo,
-  useToast,
 } from '@pancakeswap/uikit'
 import { formatAmount } from '@pancakeswap/utils/formatFractions'
 import { CurrencyLogo as CurrencyLogoWidget } from '@pancakeswap/widgets-internal'
 import { AutoRow, RowBetween, RowFixed } from 'components/Layout/Row'
 import { useGasToken } from 'hooks/useGasToken'
-import { ReactElement, memo, useMemo, useState, useCallback } from 'react'
+import { ReactElement, memo, useMemo, useState } from 'react'
 import { Field } from 'state/swap/actions'
 import { styled } from 'styled-components'
 import { warningSeverity } from 'utils/exchange'
-
-import { WSOLMint } from '@pancakeswap/solana-core-sdk'
-import { useWallet } from '@solana/wallet-adapter-react'
-import { createCloseAccountInstruction } from '@solana/spl-token-0.4'
-import { Transaction } from '@solana/web3.js'
 
 import { PancakeSwapXTag } from 'components/PancakeSwapXTag'
 import { paymasterInfo } from 'config/paymaster'
 import { usePaymaster } from 'hooks/usePaymaster'
 import { isAddressEqual } from 'utils'
 import { SlippageButton } from 'views/Swap/components/SlippageButton'
-import { InterfaceOrder, isBridgeOrder, isSVMOrder, isXOrder } from 'views/Swap/utils'
+import { InterfaceOrder, isBridgeOrder, isXOrder } from 'views/Swap/utils'
 import { useHasDynamicHook } from 'views/SwapSimplify/hooks/useHasDynamicHook'
-import { useAccountActiveChain } from 'hooks/useAccountActiveChain'
-import { useSolanaTokenBalance, useRefreshSolanaTokenBalances } from 'state/token/solanaTokenBalances'
-import { useSolanaConnectionWithRpcAtom } from 'hooks/solana/useSolanaConnectionWithRpcAtom'
 import FormattedPriceImpact from '../../components/FormattedPriceImpact'
 import { StyledBalanceMaxMini, SwapCallbackError } from '../../components/styleds'
 import { SlippageAdjustedAmounts, formatExecutionPrice } from '../utils/exchange'
@@ -130,35 +120,6 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
         ? t('Gas fees is fully sponsored')
         : t('%discount% discount on this gas fee token', { discount: gasTokenInfo.discount })),
   )
-
-  const { solanaAccount } = useAccountActiveChain()
-  const { publicKey, signTransaction } = useWallet()
-  const connection = useSolanaConnectionWithRpcAtom()
-  const { balance: wsolBalance } = useSolanaTokenBalance(solanaAccount, WSOLMint.toBase58())
-  const refreshSolanaBalances = useRefreshSolanaTokenBalances(solanaAccount)
-  const { toastSuccess, toastError } = useToast()
-
-  const handleUnwrap = useCallback(async () => {
-    try {
-      if (!publicKey || !signTransaction) throw new Error('Wallet not connected')
-      const accounts = await connection.getTokenAccountsByOwner(publicKey, { mint: WSOLMint })
-      if (accounts.value.length === 0) return
-      const tx = new Transaction()
-      accounts.value.forEach(({ pubkey }) => {
-        tx.add(createCloseAccountInstruction(pubkey, publicKey, publicKey))
-      })
-      tx.feePayer = publicKey
-      const { blockhash } = await connection.getLatestBlockhash()
-      tx.recentBlockhash = blockhash
-      const signed = await signTransaction(tx)
-      const sig = await connection.sendRawTransaction(signed.serialize())
-      await connection.confirmTransaction(sig)
-      toastSuccess(t('Success!'), t('Unwrapped WSOL to SOL'))
-      refreshSolanaBalances()
-    } catch (e: any) {
-      toastError(t('Failed'), e?.message ?? 'Unwrap failed')
-    }
-  }, [publicKey, signTransaction, connection, toastSuccess, toastError, t, refreshSolanaBalances])
 
   const severity = warningSeverity(priceImpactWithoutFee)
 
@@ -366,29 +327,6 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
             </span>
           </Flex>
         </SameTokenWarningBox>
-      )}
-
-      {isSVMOrder(order) && wsolBalance.gt(0) && (
-        <Flex
-          mt="-2"
-          mb="12px"
-          fontSize="14px"
-          alignItems="center"
-          px="8px"
-          py="8px"
-          backgroundColor="rgba(0,0,0,0.05)"
-          borderRadius="8px"
-        >
-          <CircleInfo mr="4px" />
-          <Text>
-            {t('You have %amount% WSOL that you can ', {
-              amount: wsolBalance.dividedBy(1e9).toFixed(6),
-            })}
-            <Text as="span" color="primary" cursor="pointer" onClick={handleUnwrap}>
-              {t('unwrap')}
-            </Text>
-          </Text>
-        </Flex>
       )}
 
       <AutoRow>

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/ButtonAndDetailsPanel.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/ButtonAndDetailsPanel.tsx
@@ -15,6 +15,7 @@ export const PanelWrapper = styled.div`
 `
 interface ButtonAndDetailsPanelProps {
   shouldRenderDetails?: boolean
+  tips?: React.ReactNode
 
   swapCommitButton: React.ReactNode
   pricingAndSlippage: React.ReactNode
@@ -26,6 +27,7 @@ interface ButtonAndDetailsPanelProps {
 
 export const ButtonAndDetailsPanel: React.FC<ButtonAndDetailsPanelProps> = ({
   shouldRenderDetails,
+  tips,
   swapCommitButton,
   pricingAndSlippage,
   tradeDetails,
@@ -36,6 +38,7 @@ export const ButtonAndDetailsPanel: React.FC<ButtonAndDetailsPanelProps> = ({
   const [isOpen, setIsOpen] = useAtom(swapDetailsCollapseAtom)
   return (
     <PanelWrapper>
+      {tips}
       {swapCommitButton}
       {mevSlot}
       {gasTokenSelector}

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/SwapCommitButton.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/SwapCommitButton.tsx
@@ -1,17 +1,5 @@
 import { Currency, CurrencyAmount } from '@pancakeswap/swap-sdk-core'
-import {
-  AutoColumn,
-  Box,
-  Button,
-  Dots,
-  Message,
-  MessageText,
-  Text,
-  useModal,
-  Flex,
-  CircleInfo,
-  useToast,
-} from '@pancakeswap/uikit'
+import { AutoColumn, Button, Dots, Message, MessageText, Text, useModal } from '@pancakeswap/uikit'
 import { useAddressBalance } from 'hooks/useAddressBalance'
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -63,13 +51,6 @@ import { useAccount } from 'wagmi'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { isEvm, NonEVMChainId } from '@pancakeswap/chains'
 import SolanaConnectButton from 'wallet/components/SolanaConnectButton'
-
-import { WSOLMint } from '@pancakeswap/solana-core-sdk'
-import { useWallet } from '@solana/wallet-adapter-react'
-import { createCloseAccountInstruction } from '@solana/spl-token-0.4'
-import { Transaction } from '@solana/web3.js'
-import { useSolanaTokenBalance, useRefreshSolanaTokenBalances } from 'state/token/solanaTokenBalances'
-import { useSolanaConnectionWithRpcAtom } from 'hooks/solana/useSolanaConnectionWithRpcAtom'
 
 import { ConfirmSwapModalV3 } from '../../Swap/Bridge/CrossChainConfirmSwapModal/ConfirmSwapModalV3'
 import { useParsedAmounts, useSlippageAdjustedAmounts, useSwapInputError } from '../../Swap/V3Swap/hooks'
@@ -184,12 +165,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
 }: SwapCommitButtonPropsType & CommitButtonProps) {
   const { address: account } = useAccount()
   const { t } = useTranslation()
-  const { chainId, solanaAccount } = useAccountActiveChain()
-  const { publicKey, signTransaction } = useWallet()
-  const connection = useSolanaConnectionWithRpcAtom()
-  const { balance: wsolBalance } = useSolanaTokenBalance(solanaAccount, WSOLMint.toBase58())
-  const refreshSolanaBalances = useRefreshSolanaTokenBalances(solanaAccount)
-  const { toastSuccess, toastError } = useToast()
+  const { chainId } = useAccountActiveChain()
   // form data
   const { independentField, typedValue } = useSwapState()
   const [inputCurrency, outputCurrency] = useSwapCurrency()
@@ -262,28 +238,6 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const handleAcceptChanges = useCallback(() => {
     setTradeToConfirm(order)
   }, [order])
-
-  const handleUnwrap = useCallback(async () => {
-    try {
-      if (!publicKey || !signTransaction) throw new Error('Wallet not connected')
-      const accounts = await connection.getTokenAccountsByOwner(publicKey, { mint: WSOLMint })
-      if (accounts.value.length === 0) return
-      const tx = new Transaction()
-      accounts.value.forEach(({ pubkey }) => {
-        tx.add(createCloseAccountInstruction(pubkey, publicKey, publicKey))
-      })
-      tx.feePayer = publicKey
-      const { blockhash } = await connection.getLatestBlockhash()
-      tx.recentBlockhash = blockhash
-      const signed = await signTransaction(tx)
-      const sig = await connection.sendRawTransaction(signed.serialize())
-      await connection.confirmTransaction(sig)
-      toastSuccess(t('Success!'), t('Unwrapped WSOL to SOL'))
-      refreshSolanaBalances()
-    } catch (e: any) {
-      toastError(t('Failed'), e?.message ?? 'Unwrap failed')
-    }
-  }, [publicKey, signTransaction, connection, toastSuccess, toastError, t, refreshSolanaBalances])
 
   const hasNoValidRouteError = useMemo(() => Boolean(tradeError && isSupportedErrorType(tradeError)), [tradeError])
 
@@ -502,43 +456,18 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
     return <ResetRoutesButton />
   }
 
-  const showUnwrapTip = isSVMOrder(order) && wsolBalance.gt(0)
-
   return (
-    <Box mt="0.25rem">
-      {showUnwrapTip && (
-        <Flex
-          mb="12px"
-          fontSize="14px"
-          alignItems="center"
-          px="8px"
-          py="8px"
-          backgroundColor="rgba(0,0,0,0.05)"
-          borderRadius="8px"
-        >
-          <CircleInfo mr="4px" />
-          <Text>
-            {t('You have %amount% WSOL that you can ', {
-              amount: wsolBalance.dividedBy(1e9).toFixed(6),
-            })}
-            <Text as="span" color="primary" cursor="pointer" onClick={handleUnwrap}>
-              {t('unwrap')}
-            </Text>
-          </Text>
-        </Flex>
-      )}
-      <CommitButton
-        id="swap-button"
-        width="100%"
-        data-dd-action-name="Swap commit button"
-        variant={isValid && priceImpactSeverity > 2 && !errorMessage ? 'danger' : 'primary'}
-        disabled={disabled}
-        onClick={handleSwap}
-        checkChainId={isValid ? inputCurrency?.chainId : undefined}
-      >
-        {buttonText}
-      </CommitButton>
-    </Box>
+    <CommitButton
+      id="swap-button"
+      width="100%"
+      data-dd-action-name="Swap commit button"
+      variant={isValid && priceImpactSeverity > 2 && !errorMessage ? 'danger' : 'primary'}
+      disabled={disabled}
+      onClick={handleSwap}
+      checkChainId={isValid ? inputCurrency?.chainId : undefined}
+    >
+      {buttonText}
+    </CommitButton>
   )
 })
 

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/SwapCommitButton.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/SwapCommitButton.tsx
@@ -1,5 +1,17 @@
 import { Currency, CurrencyAmount } from '@pancakeswap/swap-sdk-core'
-import { AutoColumn, Box, Button, Dots, Message, MessageText, Text, useModal } from '@pancakeswap/uikit'
+import {
+  AutoColumn,
+  Box,
+  Button,
+  Dots,
+  Message,
+  MessageText,
+  Text,
+  useModal,
+  Flex,
+  CircleInfo,
+  useToast,
+} from '@pancakeswap/uikit'
 import { useAddressBalance } from 'hooks/useAddressBalance'
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -51,6 +63,13 @@ import { useAccount } from 'wagmi'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { isEvm, NonEVMChainId } from '@pancakeswap/chains'
 import SolanaConnectButton from 'wallet/components/SolanaConnectButton'
+
+import { WSOLMint } from '@pancakeswap/solana-core-sdk'
+import { useWallet } from '@solana/wallet-adapter-react'
+import { createCloseAccountInstruction } from '@solana/spl-token-0.4'
+import { Transaction } from '@solana/web3.js'
+import { useSolanaTokenBalance, useRefreshSolanaTokenBalances } from 'state/token/solanaTokenBalances'
+import { useSolanaConnectionWithRpcAtom } from 'hooks/solana/useSolanaConnectionWithRpcAtom'
 
 import { ConfirmSwapModalV3 } from '../../Swap/Bridge/CrossChainConfirmSwapModal/ConfirmSwapModalV3'
 import { useParsedAmounts, useSlippageAdjustedAmounts, useSwapInputError } from '../../Swap/V3Swap/hooks'
@@ -165,7 +184,12 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
 }: SwapCommitButtonPropsType & CommitButtonProps) {
   const { address: account } = useAccount()
   const { t } = useTranslation()
-  const { chainId } = useAccountActiveChain()
+  const { chainId, solanaAccount } = useAccountActiveChain()
+  const { publicKey, signTransaction } = useWallet()
+  const connection = useSolanaConnectionWithRpcAtom()
+  const { balance: wsolBalance } = useSolanaTokenBalance(solanaAccount, WSOLMint.toBase58())
+  const refreshSolanaBalances = useRefreshSolanaTokenBalances(solanaAccount)
+  const { toastSuccess, toastError } = useToast()
   // form data
   const { independentField, typedValue } = useSwapState()
   const [inputCurrency, outputCurrency] = useSwapCurrency()
@@ -238,6 +262,28 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const handleAcceptChanges = useCallback(() => {
     setTradeToConfirm(order)
   }, [order])
+
+  const handleUnwrap = useCallback(async () => {
+    try {
+      if (!publicKey || !signTransaction) throw new Error('Wallet not connected')
+      const accounts = await connection.getTokenAccountsByOwner(publicKey, { mint: WSOLMint })
+      if (accounts.value.length === 0) return
+      const tx = new Transaction()
+      accounts.value.forEach(({ pubkey }) => {
+        tx.add(createCloseAccountInstruction(pubkey, publicKey, publicKey))
+      })
+      tx.feePayer = publicKey
+      const { blockhash } = await connection.getLatestBlockhash()
+      tx.recentBlockhash = blockhash
+      const signed = await signTransaction(tx)
+      const sig = await connection.sendRawTransaction(signed.serialize())
+      await connection.confirmTransaction(sig)
+      toastSuccess(t('Success!'), t('Unwrapped WSOL to SOL'))
+      refreshSolanaBalances()
+    } catch (e: any) {
+      toastError(t('Failed'), e?.message ?? 'Unwrap failed')
+    }
+  }, [publicKey, signTransaction, connection, toastSuccess, toastError, t, refreshSolanaBalances])
 
   const hasNoValidRouteError = useMemo(() => Boolean(tradeError && isSupportedErrorType(tradeError)), [tradeError])
 
@@ -456,8 +502,31 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
     return <ResetRoutesButton />
   }
 
+  const showUnwrapTip = isSVMOrder(order) && wsolBalance.gt(0)
+
   return (
     <Box mt="0.25rem">
+      {showUnwrapTip && (
+        <Flex
+          mb="12px"
+          fontSize="14px"
+          alignItems="center"
+          px="8px"
+          py="8px"
+          backgroundColor="rgba(0,0,0,0.05)"
+          borderRadius="8px"
+        >
+          <CircleInfo mr="4px" />
+          <Text>
+            {t('You have %amount% WSOL that you can ', {
+              amount: wsolBalance.dividedBy(1e9).toFixed(6),
+            })}
+            <Text as="span" color="primary" cursor="pointer" onClick={handleUnwrap}>
+              {t('unwrap')}
+            </Text>
+          </Text>
+        </Flex>
+      )}
       <CommitButton
         id="swap-button"
         width="100%"

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/UnwrapTips.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/UnwrapTips.tsx
@@ -1,15 +1,15 @@
 import React, { useCallback } from 'react'
-import { CircleInfo, Flex, Text, useToast } from '@pancakeswap/uikit'
+import { Button, Flex, InfoIcon, Text, useToast } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
-import { WSOLMint } from '@pancakeswap/solana-core-sdk'
-import { NonEVMChainId } from '@pancakeswap/chains'
 import { useWallet } from '@solana/wallet-adapter-react'
 import { createCloseAccountInstruction } from '@solana/spl-token-0.4'
 import { Transaction } from '@solana/web3.js'
 import { useSolanaTokenBalance, useRefreshSolanaTokenBalances } from 'state/token/solanaTokenBalances'
 import { useSolanaConnectionWithRpcAtom } from 'hooks/solana/useSolanaConnectionWithRpcAtom'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
-import { useSwapCurrency } from '../../Swap/V3Swap/hooks/useSwapCurrency'
+import { NonEVMChainId } from '@pancakeswap/chains'
+import { WSOLMint } from '@pancakeswap/sdk'
+import { useSwapCurrency } from 'views/Swap/V3Swap/hooks/useSwapCurrency'
 
 export const UnwrapTips: React.FC = () => {
   const { t } = useTranslation()
@@ -50,21 +50,13 @@ export const UnwrapTips: React.FC = () => {
   if (!showUnwrapTip) return null
 
   return (
-    <Flex
-      mb="12px"
-      fontSize="14px"
-      alignItems="center"
-      px="8px"
-      py="8px"
-      backgroundColor="rgba(0,0,0,0.05)"
-      borderRadius="8px"
-    >
-      <CircleInfo mr="4px" />
+    <Flex mb="12px" alignItems="center" px="8px" py="8px" backgroundColor="rgba(0,0,0,0.05)" borderRadius="8px">
+      <InfoIcon mr="4px" />
       <Text>
         {t('You have %amount% WSOL that you can ', { amount: wsolBalance.dividedBy(1e9).toFixed(6) })}
-        <Text as="span" color="primary" cursor="pointer" onClick={handleUnwrap}>
+        <Button variant="textPrimary60" onClick={handleUnwrap}>
           {t('unwrap')}
-        </Text>
+        </Button>
       </Text>
     </Flex>
   )

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/UnwrapTips.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/UnwrapTips.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback } from 'react'
+import { CircleInfo, Flex, Text, useToast } from '@pancakeswap/uikit'
+import { useTranslation } from '@pancakeswap/localization'
+import { WSOLMint } from '@pancakeswap/solana-core-sdk'
+import { NonEVMChainId } from '@pancakeswap/chains'
+import { useWallet } from '@solana/wallet-adapter-react'
+import { createCloseAccountInstruction } from '@solana/spl-token-0.4'
+import { Transaction } from '@solana/web3.js'
+import { useSolanaTokenBalance, useRefreshSolanaTokenBalances } from 'state/token/solanaTokenBalances'
+import { useSolanaConnectionWithRpcAtom } from 'hooks/solana/useSolanaConnectionWithRpcAtom'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import { useSwapCurrency } from '../../Swap/V3Swap/hooks/useSwapCurrency'
+
+export const UnwrapTips: React.FC = () => {
+  const { t } = useTranslation()
+  const { publicKey, signTransaction } = useWallet()
+  const connection = useSolanaConnectionWithRpcAtom()
+  const { solanaAccount } = useAccountActiveChain()
+  const { balance: wsolBalance } = useSolanaTokenBalance(solanaAccount, WSOLMint.toBase58())
+  const refreshSolanaBalances = useRefreshSolanaTokenBalances(solanaAccount)
+  const { toastSuccess, toastError } = useToast()
+  const [inputCurrency, outputCurrency] = useSwapCurrency()
+
+  const isSolanaSwap =
+    inputCurrency?.chainId === NonEVMChainId.SOLANA || outputCurrency?.chainId === NonEVMChainId.SOLANA
+  const showUnwrapTip = isSolanaSwap && wsolBalance.gt(0)
+
+  const handleUnwrap = useCallback(async () => {
+    try {
+      if (!publicKey || !signTransaction) throw new Error('Wallet not connected')
+      const accounts = await connection.getTokenAccountsByOwner(publicKey, { mint: WSOLMint })
+      if (accounts.value.length === 0) return
+      const tx = new Transaction()
+      accounts.value.forEach(({ pubkey }) => {
+        tx.add(createCloseAccountInstruction(pubkey, publicKey, publicKey))
+      })
+      tx.feePayer = publicKey
+      const { blockhash } = await connection.getLatestBlockhash()
+      tx.recentBlockhash = blockhash
+      const signed = await signTransaction(tx)
+      const sig = await connection.sendRawTransaction(signed.serialize())
+      await connection.confirmTransaction(sig)
+      toastSuccess(t('Success!'), t('Unwrapped WSOL to SOL'))
+      refreshSolanaBalances()
+    } catch (e: any) {
+      toastError(t('Failed'), e?.message ?? 'Unwrap failed')
+    }
+  }, [publicKey, signTransaction, connection, toastSuccess, toastError, t, refreshSolanaBalances])
+
+  if (!showUnwrapTip) return null
+
+  return (
+    <Flex
+      mb="12px"
+      fontSize="14px"
+      alignItems="center"
+      px="8px"
+      py="8px"
+      backgroundColor="rgba(0,0,0,0.05)"
+      borderRadius="8px"
+    >
+      <CircleInfo mr="4px" />
+      <Text>
+        {t('You have %amount% WSOL that you can ', { amount: wsolBalance.dividedBy(1e9).toFixed(6) })}
+        <Text as="span" color="primary" cursor="pointer" onClick={handleUnwrap}>
+          {t('unwrap')}
+        </Text>
+      </Text>
+    </Flex>
+  )
+}
+
+export default UnwrapTips

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/index.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/index.tsx
@@ -13,7 +13,6 @@ import { useAllTypeBestTrade } from 'quoter/hook/useAllTypeBestTrade'
 import { memo, Suspense, useMemo } from 'react'
 import { Field } from 'state/swap/actions'
 import { useSwapState } from 'state/swap/hooks'
-import { isSVMOrder } from 'views/Swap/utils'
 import { MevSwapDetail } from 'views/Mev/MevSwapDetail'
 import { MevToggle } from 'views/Mev/MevToggle'
 import { SwapType } from '../../Swap/types'
@@ -30,6 +29,7 @@ import { RefreshButton } from './RefreshButton'
 import { SwapSelection } from './SwapSelectionTab'
 import { TradeDetails } from './TradeDetails'
 import { TradingFee } from './TradingFee'
+import { UnwrapTips } from './UnwrapTips'
 
 export const InfinitySwapForm = memo(() => {
   const { bestOrder, refreshOrder, tradeError, tradeLoaded, refreshDisabled, pauseQuoting, resumeQuoting } =
@@ -96,6 +96,7 @@ export const InfinitySwapForm = memo(() => {
         />
       )}
       <ButtonAndDetailsPanel
+        tips={<UnwrapTips />}
         swapCommitButton={
           <CommitButton order={bestOrder} tradeLoaded={tradeLoaded} tradeError={tradeError} {...commitHooks} />
         }


### PR DESCRIPTION
## Summary
- move Solana WSOL unwrap tip and logic from the swap modal footer to the main swap button
- drop unused unwrap code in `SwapModalFooterV2`

## Testing
- `pnpm test --filter=web` *(fails: ENETUNREACH)*
- `pnpm lint --filter=web` *(fails: run failed)*

------
https://chatgpt.com/codex/tasks/task_e_6893275138a483209c66f28eb07a9d75