### PR TITLE
refactor: cache solana token prices with jotai

### DIFF
--- a/apps/web/src/hooks/solana/useSolanaTokenPrice.ts
+++ b/apps/web/src/hooks/solana/useSolanaTokenPrice.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
-
-import useSWR, { Fetcher } from 'swr'
+import { useAtomValue } from 'jotai'
+import { atomFamily } from 'jotai/utils'
+import { atomWithLoadable } from 'quoter/atom/atomWithLoadable'
+import { DeepKeyMap, isEqual } from 'utils/hash'
 
 import { WSOLMint } from '@pancakeswap/solana-core-sdk'
 import { PublicKey } from '@solana/web3.js'
@@ -9,11 +11,36 @@ const WALLET_PRICE_URL = 'https://wallet-api.pancakeswap.com/sol/v1/prices/list'
 
 type PriceReturnType = { [key: string]: number }
 
-const fetcher: Fetcher<PriceReturnType, [string, string]> = async ([url, mintList]: [string, string]) => {
-  const response = await fetch(`${url}/${mintList}`)
-  if (!response.ok) throw new Error('Failed to fetch price')
-  return response.json()
+interface SolanaTokenPriceParams {
+  mintList: string[]
+  enabled: boolean
+  version: number
 }
+
+const placeHolderMap = new DeepKeyMap<SolanaTokenPriceParams, PriceReturnType>()
+
+const solanaTokenPriceAtom = atomFamily((params: SolanaTokenPriceParams) => {
+  return atomWithLoadable(
+    async () => {
+      const { mintList, enabled } = params
+      if (!enabled || mintList.length === 0) {
+        return undefined
+      }
+      const response = await fetch(`${WALLET_PRICE_URL}/${mintList.join(',')}`)
+      if (!response.ok) {
+        throw new Error('Failed to fetch price')
+      }
+      const result: PriceReturnType = await response.json()
+      result[PublicKey.default.toBase58()] = result[WSOLMint.toBase58()]
+      placeHolderMap.set({ ...params, version: 0 }, result)
+      return result
+    },
+    {
+      placeHolderBehavior: 'stale',
+      placeHolderValue: placeHolderMap.get({ ...params, version: 0 }),
+    },
+  )
+}, isEqual)
 
 export const useSolanaTokenPrice = (props: {
   mintList: (string | PublicKey | undefined)[]
@@ -24,32 +51,23 @@ export const useSolanaTokenPrice = (props: {
   const { mintList, refreshInterval = 2 * 60 * 1000, enabled = true } = props || {}
 
   const readyList = useMemo(
-    () => Array.from(new Set(mintList.filter((m) => !!m && typeof m === 'string' && m.length === 44))),
+    () => Array.from(new Set(mintList.filter((m): m is string => !!m && typeof m === 'string' && m.length === 44))),
     [mintList],
   )
 
-  const shouldFetch = readyList.length > 0 && enabled
+  const version = Math.floor(Date.now() / refreshInterval)
 
-  const { data, isLoading, error, ...rest } = useSWR(
-    shouldFetch ? [WALLET_PRICE_URL, readyList.join(',')] : null,
-    fetcher,
-    {
-      refreshInterval,
-      dedupingInterval: refreshInterval,
-      focusThrottleInterval: refreshInterval,
-    },
-  )
-  const isEmptyResult = !isLoading && !(data && !error)
+  const loadable = useAtomValue(solanaTokenPriceAtom({ mintList: readyList, enabled, version }))
 
-  if (data) {
-    data[PublicKey.default.toBase58()] = data[WSOLMint.toBase58()]
-  }
+  const data = loadable.unwrapOr({})
+  const error = loadable.isFail() ? loadable.error : undefined
+  const isLoading = loadable.isPending()
+  const isEmptyResult = loadable.isNothing()
 
   return {
-    data: data ?? {},
+    data,
     isLoading,
     error,
     isEmptyResult,
-    ...rest,
   }
 }


### PR DESCRIPTION
## Summary
- refactor useSolanaTokenPrice to cache results with jotai atomFamily + atomWithLoadable

## Testing
- `pnpm test:config` *(fails: TS2742 in canonical-bridge useTransferConfig)*
- `pnpm lint --filter=web`


------
https://chatgpt.com/codex/tasks/task_e_6893441dcb5c832084eff307c5b7f773