### PR TITLE
feat(web): sort solana tokens by usd balance

### DIFF
--- a/apps/web/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearch.tsx
@@ -6,7 +6,7 @@ import { useUnifiedNativeCurrency } from 'hooks/useNativeCurrency'
 import { useSolanaTokenList } from 'hooks/solana/useSolanaTokenList'
 import { useSolanaTokenInfo } from 'hooks/solana/useSolanaTokenInfo'
 import { useSolanaTokenBalances } from 'state/token/solanaTokenBalances'
-import { useSolanaTokenPrice } from 'hooks/solana/useSolanaTokenPrice'
+import { useSolanaTokenPrices } from 'hooks/solana/useSolanaTokenPrice'
 import BN from 'bignumber.js'
 import { FixedSizeList } from 'react-window'
 import { useAllLists, useInactiveListUrls } from 'state/lists/hooks'
@@ -164,8 +164,8 @@ function CurrencySearch({
     () => tokenAddresses.filter((addr) => solanaBalances.balances.get(addr)?.gt(0)),
     [tokenAddresses, solanaBalances.balances],
   )
-  const { data: solanaPrices } = useSolanaTokenPrice({
-    mintList: tokenAddressesWithBalance,
+  const { data: solanaPrices } = useSolanaTokenPrices({
+    mints: tokenAddressesWithBalance,
     enabled: isSolana && tokenAddressesWithBalance.length > 0,
   })
 

--- a/apps/web/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearch.tsx
@@ -216,8 +216,8 @@ function CurrencySearch({
       return [...filteredTokens].sort((a, b) => {
         const balA = solanaBalances.balances.get(a.address) ?? new BN(0)
         const balB = solanaBalances.balances.get(b.address) ?? new BN(0)
-        const priceA = solanaPrices?.[`${NonEVMChainId.SOLANA}-${a.address}`] ?? 0
-        const priceB = solanaPrices?.[`${NonEVMChainId.SOLANA}-${b.address}`] ?? 0
+        const priceA = solanaPrices?.[a.address] ?? 0
+        const priceB = solanaPrices?.[b.address] ?? 0
         const usdA = balA.multipliedBy(priceA)
         const usdB = balB.multipliedBy(priceB)
         if (!usdA.eq(usdB)) {

--- a/apps/web/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearch.tsx
@@ -6,6 +6,8 @@ import { useUnifiedNativeCurrency } from 'hooks/useNativeCurrency'
 import { useSolanaTokenList } from 'hooks/solana/useSolanaTokenList'
 import { useSolanaTokenInfo } from 'hooks/solana/useSolanaTokenInfo'
 import { useSolanaTokenBalances } from 'state/token/solanaTokenBalances'
+import { useSolanaTokenPrice } from 'hooks/solana/useSolanaTokenPrice'
+import BN from 'bignumber.js'
 import { FixedSizeList } from 'react-window'
 import { useAllLists, useInactiveListUrls } from 'state/lists/hooks'
 import { UpdaterByChainId } from 'state/lists/updater'
@@ -158,6 +160,14 @@ function CurrencySearch({
   const tokenAddresses = useMemo(() => solanaTokens.map((t) => t.address), [solanaTokens])
   // Solana balances integration
   const solanaBalances = useSolanaTokenBalances(solanaAccount, tokenAddresses)
+  const tokenAddressesWithBalance = useMemo(
+    () => tokenAddresses.filter((addr) => solanaBalances.balances.get(addr)?.gt(0)),
+    [tokenAddresses, solanaBalances.balances],
+  )
+  const { data: solanaPrices } = useSolanaTokenPrice({
+    mintList: tokenAddressesWithBalance,
+    enabled: isSolana && tokenAddressesWithBalance.length > 0,
+  })
 
   const solanaSearchToken = useSolanaTokenInfo(isSolana ? debouncedQuery : undefined)
   const evmSearchToken = useToken(debouncedQuery, selectedChainId)
@@ -202,15 +212,33 @@ function CurrencySearch({
 
   const filteredSortedTokens: UnifiedCurrency[] = useMemo(() => {
     if (isSolana) {
+      const defaultOrder = new Map(filteredTokens.map((t, idx) => [t.address, idx]))
       return [...filteredTokens].sort((a, b) => {
-        const balA = solanaBalances.balances.get(a.address) ?? 0
-        const balB = solanaBalances.balances.get(b.address) ?? 0
-        return Number(balB) - Number(balA)
+        const balA = solanaBalances.balances.get(a.address) ?? new BN(0)
+        const balB = solanaBalances.balances.get(b.address) ?? new BN(0)
+        const priceA = solanaPrices?.[`${NonEVMChainId.SOLANA}-${a.address}`] ?? 0
+        const priceB = solanaPrices?.[`${NonEVMChainId.SOLANA}-${b.address}`] ?? 0
+        const usdA = balA.multipliedBy(priceA)
+        const usdB = balB.multipliedBy(priceB)
+        if (!usdA.eq(usdB)) {
+          return usdB.comparedTo(usdA)
+        }
+        const hasBalA = balA.gt(0)
+        const hasBalB = balB.gt(0)
+        if (hasBalA && hasBalB) {
+          if (!balA.eq(balB)) {
+            return balB.comparedTo(balA)
+          }
+        }
+        if (hasBalA !== hasBalB) {
+          return hasBalB ? 1 : -1
+        }
+        return (defaultOrder.get(a.address) ?? 0) - (defaultOrder.get(b.address) ?? 0)
       })
     }
     const tokenComparator = getTokenComparator(balances ?? {})
     return [...(queryTokens as Token[])].sort(tokenComparator)
-  }, [filteredTokens, queryTokens, balances, isSolana, solanaBalances.balances])
+  }, [filteredTokens, queryTokens, balances, isSolana, solanaBalances.balances, solanaPrices])
 
   const handleCurrencySelect = useCallback(
     (currency: UnifiedCurrency) => {

--- a/apps/web/src/hooks/solana/useSolanaTokenPrice.ts
+++ b/apps/web/src/hooks/solana/useSolanaTokenPrice.ts
@@ -4,7 +4,6 @@ import { atomFamily } from 'jotai/utils'
 import { atomWithLoadable } from 'quoter/atom/atomWithLoadable'
 import { DeepKeyMap, isEqual } from 'utils/hash'
 
-import { WSOLMint } from '@pancakeswap/solana-core-sdk'
 import { PublicKey } from '@solana/web3.js'
 
 const WALLET_PRICE_URL = 'https://wallet-api.pancakeswap.com/sol/v1/prices/list'
@@ -35,7 +34,7 @@ const solanaTokenPriceAtom = atomFamily((params: SolanaTokenPriceParams) => {
         // eslint-disable-next-line no-param-reassign
         acc[key.split('-')[1] ?? key] = val
         return acc
-      }, {})
+      }, {} as PriceReturnType)
       placeHolderMap.set({ ...params, version: 0 }, result)
       return result
     },
@@ -64,6 +63,39 @@ export const useSolanaTokenPrice = (props: {
 
   return {
     data: mint ? data[mint?.toLowerCase()] : undefined,
+    isLoading,
+    error,
+    isEmptyResult,
+  }
+}
+
+export const useSolanaTokenPrices = (props: {
+  mints: (string | PublicKey | undefined)[]
+  refreshInterval?: number
+  timeout?: number
+  enabled?: boolean
+}) => {
+  const { mints, refreshInterval = 2 * 60 * 1000, enabled = true } = props || {}
+
+  const readyList = useMemo(
+    () => Array.from(new Set(mints.filter((m): m is string => !!m && typeof m === 'string' && m.length === 44))),
+    [mints],
+  )
+  const joined = readyList.join(',')
+
+  const version = Math.floor(Date.now() / refreshInterval)
+
+  const loadable = useAtomValue(
+    solanaTokenPriceAtom({ mint: joined || undefined, enabled: enabled && joined.length > 0, version }),
+  )
+
+  const data = loadable.unwrapOr({})
+  const error = loadable.isFail() ? loadable.error : undefined
+  const isLoading = loadable.isPending()
+  const isEmptyResult = loadable.isNothing()
+
+  return {
+    data,
     isLoading,
     error,
     isEmptyResult,

--- a/apps/web/src/hooks/solana/useSolanaTokenPrice.ts
+++ b/apps/web/src/hooks/solana/useSolanaTokenPrice.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useAtomValue } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 import { atomWithLoadable } from 'quoter/atom/atomWithLoadable'
-import { DeepKeyMap, isEqual } from 'utils/hash'
+import { isEqual } from 'utils/hash'
 
 import { PublicKey } from '@solana/web3.js'
 
@@ -16,33 +16,24 @@ interface SolanaTokenPriceParams {
   version: number
 }
 
-const placeHolderMap = new DeepKeyMap<SolanaTokenPriceParams, PriceReturnType>()
-
 const solanaTokenPriceAtom = atomFamily((params: SolanaTokenPriceParams) => {
-  return atomWithLoadable(
-    async () => {
-      const { mint, enabled } = params
-      if (!enabled || !mint) {
-        return undefined
-      }
-      const response = await fetch(`${WALLET_PRICE_URL}/${mint}`)
-      if (!response.ok) {
-        throw new Error('Failed to fetch price')
-      }
-      const resp: PriceReturnType = await response.json()
-      const result = Object.entries(resp).reduce((acc, [key, val]) => {
-        // eslint-disable-next-line no-param-reassign
-        acc[key.split('-')[1] ?? key] = val
-        return acc
-      }, {} as PriceReturnType)
-      placeHolderMap.set({ ...params, version: 0 }, result)
-      return result
-    },
-    {
-      placeHolderBehavior: 'stale',
-      placeHolderValue: placeHolderMap.get({ ...params, version: 0 }),
-    },
-  )
+  return atomWithLoadable(async () => {
+    const { mint, enabled } = params
+    if (!enabled || !mint) {
+      return undefined
+    }
+    const response = await fetch(`${WALLET_PRICE_URL}/${mint}`)
+    if (!response.ok) {
+      throw new Error('Failed to fetch price')
+    }
+    const resp: PriceReturnType = await response.json()
+    const result = Object.entries(resp).reduce((acc, [key, val]) => {
+      // eslint-disable-next-line no-param-reassign
+      acc[key.split('-')[1] ?? key] = val
+      return acc
+    }, {} as PriceReturnType)
+    return result
+  })
 }, isEqual)
 
 export const useSolanaTokenPrice = (props: {
@@ -76,17 +67,11 @@ export const useSolanaTokenPrices = (props: {
   enabled?: boolean
 }) => {
   const { mints, refreshInterval = 2 * 60 * 1000, enabled = true } = props || {}
-
-  const readyList = useMemo(
-    () => Array.from(new Set(mints.filter((m): m is string => !!m && typeof m === 'string' && m.length === 44))),
-    [mints],
-  )
-  const joined = readyList.join(',')
-
+  const readyList = useMemo(() => Array.from(new Set(mints.filter((m): m is string => !!m))).join(','), [mints])
   const version = Math.floor(Date.now() / refreshInterval)
 
   const loadable = useAtomValue(
-    solanaTokenPriceAtom({ mint: joined || undefined, enabled: enabled && joined.length > 0, version }),
+    solanaTokenPriceAtom({ mint: readyList || undefined, enabled: enabled && readyList.length > 0, version }),
   )
 
   const data = loadable.unwrapOr({})


### PR DESCRIPTION
## Summary
- fetch solana token prices and calculate usd balances
- sort solana token list by usd balance, then wallet balance, then default order

## Testing
- `pnpm test` *(fails: Failed to resolve entry for package `@pancakeswap/chains`)*
- `pnpm exec eslint src/components/SearchModal/CurrencySearch.tsx`
- `pnpm exec tsc --noEmit` *(fails: Command was killed with SIGABRT (Aborted))*

------
https://chatgpt.com/codex/tasks/task_e_689362c75188832097105f94e0be54ca